### PR TITLE
allow passing in query without pathname

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 coverage
+node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.0.14
 
-- Allow passing in `query` without `pathname` for `<Link>` and `router.push`.
+- Allow passing in `query` without `pathname` to change current url parameters.
 
 ## 0.0.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.0.14
 
-- Allow passing in `query` without `pathname` in `<Link>`.
+- Allow passing in `query` without `pathname` for `<Link>` and `router.push`.
 
 ## 0.0.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.0.14
 
 - Allow passing in `query` without `pathname` to change current url parameters.
+- `router.query` can no longer be `undefined`.
 
 ## 0.0.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.14
+
+- Allow passing in `query` without `pathname` in `<Link>`.
+
 ## 0.0.13
 
 - Support search parameters. See [#17](https://github.com/tatethurston/nextjs-routes/issues/17) for more context.

--- a/src/__snapshots__/test.ts.snap
+++ b/src/__snapshots__/test.ts.snap
@@ -68,7 +68,7 @@ declare module \\"next/router\\" {
   export interface NextRouter<P extends Pathname = Pathname> extends Omit<Router, \\"push\\" | \\"replace\\"> {
     pathname: P;
     route: P; 
-    query: QueryForPathname[P]
+    query: Exclude<QueryForPathname[P], undefined>
     push(url: RouteOrQuery, as?: string, options?: TransitionOptions): Promise<boolean>;
     replace(
       url: RouteOrQuery,

--- a/src/__snapshots__/test.ts.snap
+++ b/src/__snapshots__/test.ts.snap
@@ -34,12 +34,14 @@ type QueryForPathname = {
   [K in Route as K[\\"pathname\\"]]: K[\\"query\\"]
 };
 
+type RouteOrQuery = Route | { query: Query }
+
 declare module \\"next/link\\" {
   import type { LinkProps as NextLinkProps } from \\"next/dist/client/link\\";
   import type { PropsWithChildren, MouseEventHandler } from \\"react\\";
 
   export interface LinkProps extends Omit<NextLinkProps, \\"href\\"> {
-    href: Route | { query: Query };
+    href: RouteOrQuery;
   }
 
   declare function Link(
@@ -67,9 +69,9 @@ declare module \\"next/router\\" {
     pathname: P;
     route: P; 
     query: QueryForPathname[P]
-    push(url: Route, as?: string, options?: TransitionOptions): Promise<boolean>;
+    push(url: RouteOrQuery, as?: string, options?: TransitionOptions): Promise<boolean>;
     replace(
-      url: Route,
+      url: RouteOrQuery,
       as?: string,
       options?: TransitionOptions
     ): Promise<boolean>;

--- a/src/__snapshots__/test.ts.snap
+++ b/src/__snapshots__/test.ts.snap
@@ -39,7 +39,7 @@ declare module \\"next/link\\" {
   import type { PropsWithChildren, MouseEventHandler } from \\"react\\";
 
   export interface LinkProps extends Omit<NextLinkProps, \\"href\\"> {
-    href: Route;
+    href: Route | { query: Query };
   }
 
   declare function Link(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -136,12 +136,14 @@ type QueryForPathname = {
   [K in Route as K["pathname"]]: K["query"]
 };
 
+type RouteOrQuery = Route | { query: Query }
+
 declare module "next/link" {
   import type { LinkProps as NextLinkProps } from "next/dist/client/link";
   import type { PropsWithChildren, MouseEventHandler } from "react";
 
   export interface LinkProps extends Omit<NextLinkProps, "href"> {
-    href: Route | { query: Query };
+    href: RouteOrQuery;
   }
 
   declare function Link(
@@ -169,9 +171,9 @@ declare module "next/router" {
     pathname: P;
     route: P; 
     query: QueryForPathname[P]
-    push(url: Route | { query: Query }, as?: string, options?: TransitionOptions): Promise<boolean>;
+    push(url: RouteOrQuery, as?: string, options?: TransitionOptions): Promise<boolean>;
     replace(
-      url: Route,
+      url: RouteOrQuery,
       as?: string,
       options?: TransitionOptions
     ): Promise<boolean>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -169,7 +169,7 @@ declare module "next/router" {
     pathname: P;
     route: P; 
     query: QueryForPathname[P]
-    push(url: Route, as?: string, options?: TransitionOptions): Promise<boolean>;
+    push(url: Route | { query: Query }, as?: string, options?: TransitionOptions): Promise<boolean>;
     replace(
       url: Route,
       as?: string,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -141,7 +141,7 @@ declare module "next/link" {
   import type { PropsWithChildren, MouseEventHandler } from "react";
 
   export interface LinkProps extends Omit<NextLinkProps, "href"> {
-    href: Route;
+    href: Route | { query: Query };
   }
 
   declare function Link(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -170,7 +170,7 @@ declare module "next/router" {
   export interface NextRouter<P extends Pathname = Pathname> extends Omit<Router, "push" | "replace"> {
     pathname: P;
     route: P; 
-    query: QueryForPathname[P]
+    query: Exclude<QueryForPathname[P], undefined>
     push(url: RouteOrQuery, as?: string, options?: TransitionOptions): Promise<boolean>;
     replace(
       url: RouteOrQuery,


### PR DESCRIPTION
Next's `<Link>` allows us to pass in `query` without having to specify the `pathname`, assuming that we are changing query parameters on the same URL that the user is currently on. This PR updates the types to allow doing that with nextjs-routes.