### PR TITLE
fix prettier peer dependency

### DIFF
--- a/public.package.json
+++ b/public.package.json
@@ -15,7 +15,13 @@
   "sideEffects": false,
   "types": "index.d.ts",
   "peerDependencies": {
-    "next": "*"
+    "next": "*",
+    "prettier": "^2.2.1"
+  },
+  "peerDependenciesMeta": {
+    "prettier": {
+      "optional": true
+    }
   },
   "keywords": [
     "link",


### PR DESCRIPTION
We need this so npm installs correctly. I think this also fixes it for yarn v3 and pnpm.

See https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependenciesmeta for docs on `peerDependenciesMeta`