### PR TITLE
re-export from `next/link` and `next/router`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.17
+
+- re-export types from `next/link` and `next/router`
+
 ## 0.0.16
 
 - fixed prettier as an optional peer dependency

--- a/e2e/nextjs-routes.d.ts
+++ b/e2e/nextjs-routes.d.ts
@@ -14,6 +14,7 @@ declare module "next/link" {
   import type { Route } from "nextjs-routes";
   import type { LinkProps as NextLinkProps } from "next/dist/client/link";
   import type { PropsWithChildren, MouseEventHandler } from "react";
+  export * from "next/dist/client/link";
 
   type RouteOrQuery = Route | { query?: { [key: string]: string | undefined } };
 

--- a/e2e/nextjs-routes.d.ts
+++ b/e2e/nextjs-routes.d.ts
@@ -39,7 +39,8 @@ declare module "next/link" {
 declare module "next/router" {
   import type { Route } from "nextjs-routes";
   import type { NextRouter as Router } from "next/dist/client/router";
-  export { RouterEvent } from "next/dist/client/router";
+  export * from "next/dist/client/router";
+  export { default } from "next/dist/client/router";
 
   type TransitionOptions = Parameters<Router["push"]>[2];
 

--- a/e2e/typetest.tsx
+++ b/e2e/typetest.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { LinkProps } from "next/link";
 import { useRouter, RouterEvent, NextRouter } from "next/router";
 import type { Route } from "nextjs-routes";
 
@@ -44,6 +45,15 @@ function expectType<T>(_value: T) {}
 />;
 // @ts-expect-error replace typo
 <Link href={{ query: {} }} replacey />;
+
+// LinkProps
+
+// ensure LinkProps is our LinkProps, not the untyped one
+
+expectType<LinkProps['href']>({ pathname: '/' })
+
+// @ts-expect-error invalid pathname
+expectType<LinkProps['href']>({ pathname: '/invalid' })
 
 // next/router
 const router = useRouter();
@@ -137,12 +147,12 @@ routerEvent = "routeChangeStarty";
 
 // ensure NextRouter is our NextRouter, not the untyped one
 
-let nextRouter: NextRouter = undefined as unknown as NextRouter
+let nextRouter: NextRouter = undefined as unknown as NextRouter;
 
-nextRouter.push({ pathname: '/' })
+nextRouter.push({ pathname: "/" });
 
 // @ts-expect-error invalid pathname
-nextRouter.push({ pathname: '/invalid' })
+nextRouter.push({ pathname: "/invalid" });
 
 // nextjs-routes
 

--- a/e2e/typetest.tsx
+++ b/e2e/typetest.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { useRouter, RouterEvent } from "next/router";
+import { useRouter, RouterEvent, NextRouter } from "next/router";
 import type { Route } from "nextjs-routes";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
@@ -132,6 +132,17 @@ let routerEvent: RouterEvent;
 routerEvent = "routeChangeStart";
 // @ts-expect-error event typo
 routerEvent = "routeChangeStarty";
+
+// NextRouter
+
+// ensure NextRouter is our NextRouter, not the untyped one
+
+let nextRouter: NextRouter = undefined as unknown as NextRouter
+
+nextRouter.push({ pathname: '/' })
+
+// @ts-expect-error invalid pathname
+nextRouter.push({ pathname: '/invalid' })
 
 // nextjs-routes
 

--- a/e2e/typetest.tsx
+++ b/e2e/typetest.tsx
@@ -50,10 +50,10 @@ function expectType<T>(_value: T) {}
 
 // ensure LinkProps is our LinkProps, not the untyped one
 
-expectType<LinkProps['href']>({ pathname: '/' })
+expectType<LinkProps["href"]>({ pathname: "/" });
 
 // @ts-expect-error invalid pathname
-expectType<LinkProps['href']>({ pathname: '/invalid' })
+expectType<LinkProps["href"]>({ pathname: "/invalid" });
 
 // next/router
 const router = useRouter();

--- a/src/__snapshots__/test.ts.snap
+++ b/src/__snapshots__/test.ts.snap
@@ -58,7 +58,8 @@ declare module \\"next/link\\" {
 declare module \\"next/router\\" {
   import type { Route } from \\"nextjs-routes\\";
   import type { NextRouter as Router } from \\"next/dist/client/router\\";
-  export { RouterEvent } from \\"next/dist/client/router\\";
+  export * from \\"next/dist/client/router\\";
+  export { default } from 'next/dist/client/router'
 
   type TransitionOptions = Parameters<Router[\\"push\\"]>[2];
 

--- a/src/__snapshots__/test.ts.snap
+++ b/src/__snapshots__/test.ts.snap
@@ -33,6 +33,7 @@ declare module \\"next/link\\" {
   import type { Route } from \\"nextjs-routes\\";
   import type { LinkProps as NextLinkProps } from \\"next/dist/client/link\\";
   import type { PropsWithChildren, MouseEventHandler } from \\"react\\";
+  export * from \\"next/dist/client/link\\";
 
   type RouteOrQuery = Route | { query?: { [key: string]: string | undefined } };
 
@@ -59,7 +60,7 @@ declare module \\"next/router\\" {
   import type { Route } from \\"nextjs-routes\\";
   import type { NextRouter as Router } from \\"next/dist/client/router\\";
   export * from \\"next/dist/client/router\\";
-  export { default } from 'next/dist/client/router'
+  export { default } from \\"next/dist/client/router\\";
 
   type TransitionOptions = Parameters<Router[\\"push\\"]>[2];
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -160,7 +160,8 @@ declare module "next/link" {
 declare module "next/router" {
   import type { Route } from "nextjs-routes";
   import type { NextRouter as Router } from "next/dist/client/router";
-  export { RouterEvent } from "next/dist/client/router";
+  export * from "next/dist/client/router";
+  export { default } from 'next/dist/client/router'
 
   type TransitionOptions = Parameters<Router["push"]>[2];
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -135,6 +135,7 @@ declare module "next/link" {
   import type { Route } from "nextjs-routes";
   import type { LinkProps as NextLinkProps } from "next/dist/client/link";
   import type { PropsWithChildren, MouseEventHandler } from "react";
+  export * from "next/dist/client/link";
 
   type RouteOrQuery = Route | { query?: { [key: string]: string | undefined } };
 
@@ -161,7 +162,7 @@ declare module "next/router" {
   import type { Route } from "nextjs-routes";
   import type { NextRouter as Router } from "next/dist/client/router";
   export * from "next/dist/client/router";
-  export { default } from 'next/dist/client/router'
+  export { default } from "next/dist/client/router";
 
   type TransitionOptions = Parameters<Router["push"]>[2];
 


### PR DESCRIPTION
Now that types are exported from `next/link` and `next/router` we need to re-export all types that we don't override from Next itself or they cannot be used.