### PR TITLE
Add file parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "examples:regen": "npm run examples:each --command='npx next build'",
     "examples:setup": "npm run examples:each --command='npm install'",
     "lint": "npm run typecheck && prettier --check . && prettier-package-json --list-different '{,public.,example/}package.json' && eslint .",
-    "lint:fix": "prettier --write '**/*.{ts,tsx,md,json}' && prettier-package-json --write '{,public.,example/}package.json' && eslint --fix .",
+    "lint:fix": "prettier --write '**/*.{ts,cts,mts,tsx,md,json}' && prettier-package-json --write '{,public.,example/}package.json' && eslint --fix .",
     "package:build": "npm install && npm run build:module && npm run build:commonjs && npm run package:prune && npm run package:copy:files && chmod +x dist/cli.js",
     "package:copy:files": "cp ./LICENSE ./README.md dist/ && cp ./public.package.json dist/package.json",
     "package:prune": "find dist -name *.test.* | xargs rm -f",

--- a/src/core.ts
+++ b/src/core.ts
@@ -196,12 +196,12 @@ const logger: Pick<Console, "error"> = {
   error: (str: string) => console.error("[nextjs-routes] " + str),
 };
 
-export function writeNextjsRoutes(pagesDirectory: string): void {
+export function writeNextjsRoutes(pagesDirectory: string, generatedFileLocation: string): void {
   const files = findFiles(join(".", pagesDirectory));
   const routes = nextRoutes(files, pagesDirectory);
   const generated = generate(routes);
 
-  writeFileSync("nextjs-routes.d.ts", generated);
+  writeFileSync(generatedFileLocation, generated);
 }
 
 export function cli(): void {
@@ -214,6 +214,6 @@ export function cli(): void {
   `);
     process.exit(1);
   } else {
-    writeNextjsRoutes(pagesDirectory);
+    writeNextjsRoutes(pagesDirectory, 'nextjs-routes.d.ts');
   }
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -196,12 +196,15 @@ const logger: Pick<Console, "error"> = {
   error: (str: string) => console.error("[nextjs-routes] " + str),
 };
 
-export function writeNextjsRoutes(pagesDirectory: string, generatedFileLocation: string): void {
+export function writeNextjsRoutes(
+  pagesDirectory: string,
+  outputFilepath: string
+): void {
   const files = findFiles(join(".", pagesDirectory));
   const routes = nextRoutes(files, pagesDirectory);
   const generated = generate(routes);
 
-  writeFileSync(generatedFileLocation, generated);
+  writeFileSync(outputFilepath, generated);
 }
 
 export function cli(): void {
@@ -214,6 +217,6 @@ export function cli(): void {
   `);
     process.exit(1);
   } else {
-    writeNextjsRoutes(pagesDirectory, 'nextjs-routes.d.ts');
+    writeNextjsRoutes(pagesDirectory, "nextjs-routes.d.ts");
   }
 }

--- a/src/next-config.cts
+++ b/src/next-config.cts
@@ -41,7 +41,10 @@ class NextJSRoutesPlugin implements WebpackPluginInstance {
 
   apply() {
     const pagesDirectory = getPagesDirectory();
-    const outputFilepath = join(this.options?.outDir ?? "", "nextjs-routes.d.ts");
+    const outputFilepath = join(
+      this.options?.outDir ?? "",
+      "nextjs-routes.d.ts"
+    );
     if (pagesDirectory) {
       if (this.config.watch) {
         const dir = join(process.cwd(), pagesDirectory);
@@ -49,7 +52,10 @@ class NextJSRoutesPlugin implements WebpackPluginInstance {
           persistent: true,
         });
         // batch changes
-        const generate = debounce(() => writeNextjsRoutes(pagesDirectory, outputFilepath), 50);
+        const generate = debounce(
+          () => writeNextjsRoutes(pagesDirectory, outputFilepath),
+          50
+        );
         watcher.on("add", generate).on("unlink", generate);
       } else {
         writeNextjsRoutes(pagesDirectory, outputFilepath);
@@ -58,7 +64,10 @@ class NextJSRoutesPlugin implements WebpackPluginInstance {
   }
 }
 
-export function withRoutes(nextConfig: NextConfig, options?: NextJSRoutesOptions): NextConfig {
+export function withRoutes(
+  nextConfig: NextConfig,
+  options?: NextJSRoutesOptions
+): NextConfig {
   return {
     ...nextConfig,
     webpack: (config: Configuration, context) => {
@@ -68,9 +77,12 @@ export function withRoutes(nextConfig: NextConfig, options?: NextJSRoutesOptions
 
       // only watch in development
       config.plugins.push(
-        new NextJSRoutesPlugin({
-          watch: context.dev && !context.isServer,
-        }, options)
+        new NextJSRoutesPlugin(
+          {
+            watch: context.dev && !context.isServer,
+          },
+          options
+        )
       );
 
       // invoke any existing webpack extensions

--- a/src/next-config.cts
+++ b/src/next-config.cts
@@ -27,8 +27,8 @@ interface NextJSRoutesPluginConfig {
 
 class NextJSRoutesPlugin implements WebpackPluginInstance {
   constructor(
-    private config: NextJSRoutesPluginConfig,
-    private generatedFileLocation: string
+    private readonly config: NextJSRoutesPluginConfig,
+    private readonly generatedFileLocation: string
   ) {}
 
   apply() {
@@ -49,7 +49,7 @@ class NextJSRoutesPlugin implements WebpackPluginInstance {
   }
 }
 
-export function withRoutes(nextConfig: NextConfig, generatedFileLocation = 'nextjs-routes.d.ts'): NextConfig {
+export function withRoutes(nextConfig: NextConfig, generatedFileLocation = "nextjs-routes.d.ts"): NextConfig {
   return {
     ...nextConfig,
     webpack: (config: Configuration, context) => {


### PR DESCRIPTION
This PR adds support for passing a file path parameter to `withRoutes`, in which the generated types should be written to. This is convenient for projects that like to keep things tidy and place all `d.ts` files inside a `types` folder.