### PR TITLE
Allow string hrefs in Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ function Home() {
         query: { foo: "test" },
       }}
     >
-      <a>About us</a>
+      About us
     </Link>
   );
 }

--- a/README.md
+++ b/README.md
@@ -95,6 +95,18 @@ function Home() {
 export default Home;
 ```
 
+If the route doesn't have any query parameters, you can also use the more compact version of `Link` where `href` is a string (also constrained to be one of your application's path names):
+
+```tsx
+import Link from "next/link";
+
+function Home() {
+  return <Link href="/foos">Foos</Link>;
+}
+
+export default Home;
+```
+
 ### useRouter
 
 `useRouter`'s returned router instance types for `push`, `replace` and `query` are now typed based on your application routes.

--- a/e2e/nextjs-routes.d.ts
+++ b/e2e/nextjs-routes.d.ts
@@ -36,7 +36,7 @@ declare module "next/link" {
   type RouteOrQuery = Route | { query?: { [key: string]: string | string[] | undefined } };
 
   export interface LinkProps extends Omit<NextLinkProps, "href" | "locale"> {
-    href: RouteOrQuery;
+    href: Route["pathname"] | RouteOrQuery;
     locale?: false;
   }
 

--- a/e2e/typetest.tsx
+++ b/e2e/typetest.tsx
@@ -8,6 +8,12 @@ function expectType<T>(_value: T) {}
 
 // next/link
 
+// Links with string hrefs
+<Link href="/" />;
+<Link href="/foos/[foo]" />;
+// @ts-expect-error bar isn't a valid path name
+<Link href="/bar" />;
+
 // Path without dynamic segments
 <Link href={{ pathname: "/" }} />;
 <Link href={{ pathname: "/", query: undefined }} />;

--- a/examples/intl/nextjs-routes.d.ts
+++ b/examples/intl/nextjs-routes.d.ts
@@ -39,7 +39,7 @@ declare module "next/link" {
   type RouteOrQuery = Route | { query?: { [key: string]: string | string[] | undefined } };
 
   export interface LinkProps extends Omit<NextLinkProps, "href" | "locale"> {
-    href: RouteOrQuery;
+    href: Route["pathname"] | RouteOrQuery;
     locale?: Locale | false;
   }
 

--- a/examples/typescript/types/nextjs-routes.d.ts
+++ b/examples/typescript/types/nextjs-routes.d.ts
@@ -38,7 +38,7 @@ declare module "next/link" {
   type RouteOrQuery = Route | { query?: { [key: string]: string | string[] | undefined } };
 
   export interface LinkProps extends Omit<NextLinkProps, "href" | "locale"> {
-    href: RouteOrQuery;
+    href: Route["pathname"] | RouteOrQuery;
     locale?: false;
   }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -154,7 +154,7 @@ declare module "next/link" {
   type RouteOrQuery = Route | { query?: ${unknownQueryParamsType} };
 
   export interface LinkProps extends Omit<NextLinkProps, "href" | "locale"> {
-    href: RouteOrQuery;
+    href: Route["pathname"] | RouteOrQuery;
     locale?: ${!i18n.locales.length ? "false" : `Locale | false`};
   }
 


### PR DESCRIPTION
Adds the feature requested in #83.

Also, as another housekeeping change, I noticed that the first example on how to use `Link` had a `Link` wrapping an `<a></a>`, which requires the outer component to use `passHref`. Because this is mostly used for styling purposes and not really relevant to illustrate the use of the component, I just removed the `<a></a>`.