### PR TITLE
Adds `cwd` to help with monorepos

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,12 @@ function debounce<Fn extends (...args: unknown[]) => unknown>(
 
 interface NextJSRoutesPluginOptions extends WithRoutesOptions {
   watch: boolean;
+
+  /**
+   * If you are getting the `Could not find a Next.js pages directory` error,
+   * try passing `cwd: __dirname` from your `next.config.js`.
+   */
+  cwd?: string;
 }
 
 class NextJSRoutesPlugin implements WebpackPluginInstance {
@@ -32,9 +38,11 @@ class NextJSRoutesPlugin implements WebpackPluginInstance {
   ) {}
 
   apply() {
-    const watchDirs = [getPagesDirectory(), getAppDirectory()]
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    const cwd = this.options?.cwd ?? process.cwd();
+    const watchDirs = [getPagesDirectory(cwd), getAppDirectory(cwd)]
       .filter((x) => x != undefined)
-      .map((dir) => join(process.cwd(), dir as string));
+      .map((dir) => join(cwd, dir as string));
 
     if (watchDirs.length > 0) {
       const options = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,17 +2,17 @@ import { existsSync, readdirSync, statSync } from "fs";
 import { join } from "path";
 
 // istanbul ignore next: io mocking not worthwhile
-export function getPagesDirectory(): string | undefined {
+export function getPagesDirectory(cwd = process.cwd()): string | undefined {
   const dirs = ["pages", join("src", "pages")];
   for (const dir of dirs) {
-    if (existsSync(dir)) {
+    if (existsSync(join(cwd, dir))) {
       return dir;
     }
   }
 }
 
-export function getAppDirectory(): string | undefined {
-  if (existsSync("app")) {
+export function getAppDirectory(cwd = process.cwd()): string | undefined {
+  if (existsSync(join(cwd, "app"))) {
     return "app";
   }
 }


### PR DESCRIPTION
Adds an option to pass `cwd` to avoid having to do this workaround https://github.com/tatethurston/nextjs-routes/issues/73#issuecomment-1299529571