### PR TITLE
Change keyword Nextjs -> NextJS

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
+import { writeNextJSRoutes } from "./core.js";
 import { getAppDirectory, getPagesDirectory } from "./utils.js";
-import { writeNextjsRoutes } from "./core.js";
 
 const logger: Pick<Console, "error" | "info"> = {
   error: (str: string) => console.error("[nextjs-routes] " + str),
@@ -22,7 +22,7 @@ function cli(): void {
   `);
     process.exit(1);
   } else {
-    writeNextjsRoutes({});
+    writeNextJSRoutes({});
     logger.info("Generated route types.");
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,11 +3,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
+import { watch } from "chokidar";
 import type { NextConfig } from "next";
 import type { Configuration, WebpackPluginInstance } from "webpack";
+import { NextJSRoutesOptions, logger, writeNextJSRoutes } from "./core.js";
 import { getAppDirectory, getPagesDirectory } from "./utils.js";
-import { watch } from "chokidar";
-import { logger, NextJSRoutesOptions, writeNextjsRoutes } from "./core.js";
 
 type WebpackConfigContext = Parameters<NonNullable<NextConfig["webpack"]>>[1];
 
@@ -66,10 +66,10 @@ class NextJSRoutesPlugin implements WebpackPluginInstance {
         persistent: true,
       });
       // batch changes
-      const generate = debounce(() => writeNextjsRoutes(options), 50);
+      const generate = debounce(() => writeNextJSRoutes(options), 50);
       watcher.on("add", generate).on("unlink", generate);
     } else {
-      writeNextjsRoutes(options);
+      writeNextJSRoutes(options);
     }
   }
 }

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -1,5 +1,5 @@
 import { existsSync, writeFileSync } from "fs";
-import { writeNextjsRoutes } from "./core.js";
+import { writeNextJSRoutes } from "./core.js";
 import { findFiles } from "./utils.js";
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -25,7 +25,7 @@ describe("route generation", () => {
     // getPageRoutes
     existsSyncMock.mockImplementationOnce(() => true);
     findFilesMock.mockReturnValueOnce([]);
-    writeNextjsRoutes({});
+    writeNextJSRoutes({});
     expect(writeFileSyncMock.mock.calls).toMatchSnapshot();
   });
 
@@ -35,7 +35,7 @@ describe("route generation", () => {
       .mockImplementationOnce(() => false)
       .mockImplementationOnce(() => true);
     findFilesMock.mockReturnValueOnce(["src\\pages\\[foo]\\bar\\index.ts"]);
-    writeNextjsRoutes({});
+    writeNextJSRoutes({});
     expect(writeFileSyncMock.mock.calls).toMatchSnapshot();
   });
 
@@ -43,7 +43,7 @@ describe("route generation", () => {
     // getPageRoutes
     existsSyncMock.mockImplementationOnce(() => true);
     findFilesMock.mockReturnValueOnce(["pages/index.tsx", "pages/index.ts"]);
-    writeNextjsRoutes({});
+    writeNextJSRoutes({});
     expect(writeFileSyncMock.mock.calls).toMatchSnapshot();
   });
 
@@ -75,7 +75,7 @@ describe("route generation", () => {
       "pages/settings/foo.ts",
       "pages/settings/index.ts",
     ]);
-    writeNextjsRoutes({});
+    writeNextJSRoutes({});
     expect(writeFileSyncMock.mock.calls).toMatchSnapshot();
   });
 
@@ -90,7 +90,7 @@ describe("route generation", () => {
       "app/foo/page.tsx",
       "app/bar/page.ts",
     ]);
-    writeNextjsRoutes({});
+    writeNextJSRoutes({});
     expect(writeFileSyncMock.mock.calls).toMatchSnapshot();
   });
 
@@ -100,7 +100,7 @@ describe("route generation", () => {
         // getPageRoutes
         existsSyncMock.mockImplementationOnce(() => true);
         findFilesMock.mockReturnValueOnce(["pages/404.ts", "pages/404.md"]);
-        writeNextjsRoutes({});
+        writeNextJSRoutes({});
         expect(writeFileSyncMock.mock.calls).toMatchSnapshot();
       });
 
@@ -113,7 +113,7 @@ describe("route generation", () => {
           "pages/foo/index.page.tsx",
           "pages/foo/index.test.tsx",
         ]);
-        writeNextjsRoutes({
+        writeNextJSRoutes({
           pageExtensions: ["ts", "md", "page.tsx"],
         });
         expect(writeFileSyncMock.mock.calls).toMatchSnapshot();
@@ -124,7 +124,7 @@ describe("route generation", () => {
       // getPageRoutes
       existsSyncMock.mockImplementationOnce(() => true);
       findFilesMock.mockReturnValueOnce(["pages/404.ts"]);
-      writeNextjsRoutes({ outDir: "src" });
+      writeNextJSRoutes({ outDir: "src" });
       expect(writeFileSyncMock.mock.calls).toMatchSnapshot();
     });
 
@@ -132,7 +132,7 @@ describe("route generation", () => {
       // getPageRoutes
       existsSyncMock.mockImplementationOnce(() => true);
       findFilesMock.mockReturnValueOnce(["pages/index.ts"]);
-      writeNextjsRoutes({
+      writeNextJSRoutes({
         i18n: {
           locales: ["en-US", "fr", "nl-NL"],
           defaultLocale: "en-US",

--- a/src/core.ts
+++ b/src/core.ts
@@ -384,7 +384,7 @@ export function getPageRoutes(files: string[], opts: Opts): string[] {
   );
 }
 
-export function writeNextjsRoutes(options: NextJSRoutesOptions): void {
+export function writeNextJSRoutes(options: NextJSRoutesOptions): void {
   const defaultOptions = {
     dir: process.cwd(),
     outDir: "",


### PR DESCRIPTION
Uniforms the "NextJSRoutesOptions" and "Nextjs" keywords, which are the options types of the function "writeNextjsRoutes". This makes the flow of reading code smooth.

I'm sorry if the phrase is not unified due to the function name convention and the type declaration convention.