### PR TITLE
Add pnpm script and bash in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@
 1. Add this package to your project:
 
    ```bash
-    npm install nextjs-routes
-    # or
-    yarn add nextjs-routes
-    # or
-    pnpm add nextjs-routes
-    ```
+   npm install nextjs-routes
+   # or
+   yarn add nextjs-routes
+   # or
+   pnpm add nextjs-routes
+   ```
 
 2. Update your `next.config.js`:
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,14 @@
 
 1. Add this package to your project:
 
-   `npm install nextjs-routes` or `yarn add nextjs-routes`
+   ```bash
+    npm install nextjs-routes
+    # or
+    yarn add nextjs-routes
+    # or
+    pnpm add nextjs-routes
+    ```
+
 
 2. Update your `next.config.js`:
 
@@ -58,13 +65,19 @@
      reactStrictMode: true,
    };
 
+   
+
    - module.exports = nextConfig;
    + module.exports = withRoutes(nextConfig);
    ```
 
 3. Start or build your next project:
 
-   `npx next dev` or `npx next build`
+   ```bash
+   npx next dev
+   # or
+   npx next build
+   ```
 
 That's it! A `nextjs-routes.d.ts` file will be generated the first time you start your server. Check this file into version control. `next/link` and `next/router` type definitions have been augmented to verify your application's routes. No more broken links, and you get route autocompletion 🙌.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 1. Add this package to your project:
 
-   ```bash
+   ```sh
    npm install nextjs-routes
    # or
    yarn add nextjs-routes
@@ -70,7 +70,7 @@
 
 3. Start or build your next project:
 
-   ```bash
+   ```sh
    npx next dev
    # or
    npx next build

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@
     pnpm add nextjs-routes
     ```
 
-
 2. Update your `next.config.js`:
 
    ```diff
@@ -64,8 +63,6 @@
    const nextConfig = {
      reactStrictMode: true,
    };
-
-   
 
    - module.exports = nextConfig;
    + module.exports = withRoutes(nextConfig);


### PR DESCRIPTION
Your package manager did not specify pnpm in the install script even though it was pnpm. This part has been added and the structure has been changed to allow short reading for readability.

As a front-end developer using nextjs, thank you so much for developing an open source project like this.