### PR TITLE
Fix import nextjs type

### DIFF
--- a/e2e/nextjs-routes.d.ts
+++ b/e2e/nextjs-routes.d.ts
@@ -8,7 +8,7 @@ declare module "nextjs-routes" {
   import type {
     GetServerSidePropsContext as NextGetServerSidePropsContext,
     GetServerSidePropsResult as NextGetServerSidePropsResult
-  } from "nextjs";
+  } from "next";
 
   export type Route =
     | DynamicRoute<"/[...slug]", { "slug": string[] }>

--- a/examples/app/nextjs-routes.d.ts
+++ b/examples/app/nextjs-routes.d.ts
@@ -8,7 +8,7 @@ declare module "nextjs-routes" {
   import type {
     GetServerSidePropsContext as NextGetServerSidePropsContext,
     GetServerSidePropsResult as NextGetServerSidePropsResult
-  } from "nextjs";
+  } from "next";
 
   export type Route =
     | DynamicRoute<"/[store]", { "store": string }>

--- a/examples/intl/nextjs-routes.d.ts
+++ b/examples/intl/nextjs-routes.d.ts
@@ -8,7 +8,7 @@ declare module "nextjs-routes" {
   import type {
     GetServerSidePropsContext as NextGetServerSidePropsContext,
     GetServerSidePropsResult as NextGetServerSidePropsResult
-  } from "nextjs";
+  } from "next";
 
   export type Route =
     | DynamicRoute<"/[store]", { "store": string }>

--- a/examples/typescript/types/nextjs-routes.d.ts
+++ b/examples/typescript/types/nextjs-routes.d.ts
@@ -8,7 +8,7 @@ declare module "nextjs-routes" {
   import type {
     GetServerSidePropsContext as NextGetServerSidePropsContext,
     GetServerSidePropsResult as NextGetServerSidePropsResult
-  } from "nextjs";
+  } from "next";
 
   export type Route =
     | StaticRoute<"/api/hello">

--- a/src/__snapshots__/core.test.ts.snap
+++ b/src/__snapshots__/core.test.ts.snap
@@ -14,7 +14,7 @@ declare module "nextjs-routes" {
   import type {
     GetServerSidePropsContext as NextGetServerSidePropsContext,
     GetServerSidePropsResult as NextGetServerSidePropsResult
-  } from "nextjs";
+  } from "next";
 
   export type Route =
     | StaticRoute<"/">
@@ -194,7 +194,7 @@ declare module "nextjs-routes" {
   import type {
     GetServerSidePropsContext as NextGetServerSidePropsContext,
     GetServerSidePropsResult as NextGetServerSidePropsResult
-  } from "nextjs";
+  } from "next";
 
   export type Route =
     | StaticRoute<"/">;
@@ -396,7 +396,7 @@ declare module "nextjs-routes" {
   import type {
     GetServerSidePropsContext as NextGetServerSidePropsContext,
     GetServerSidePropsResult as NextGetServerSidePropsResult
-  } from "nextjs";
+  } from "next";
 
   export type Route =
     | StaticRoute<"/404">;
@@ -574,7 +574,7 @@ declare module "nextjs-routes" {
   import type {
     GetServerSidePropsContext as NextGetServerSidePropsContext,
     GetServerSidePropsResult as NextGetServerSidePropsResult
-  } from "nextjs";
+  } from "next";
 
   export type Route =
     | StaticRoute<"/404">
@@ -754,7 +754,7 @@ declare module "nextjs-routes" {
   import type {
     GetServerSidePropsContext as NextGetServerSidePropsContext,
     GetServerSidePropsResult as NextGetServerSidePropsResult
-  } from "nextjs";
+  } from "next";
 
   export type Route =
     | StaticRoute<"/404">;
@@ -932,7 +932,7 @@ declare module "nextjs-routes" {
   import type {
     GetServerSidePropsContext as NextGetServerSidePropsContext,
     GetServerSidePropsResult as NextGetServerSidePropsResult
-  } from "nextjs";
+  } from "next";
 
   export type Route =
     | StaticRoute<"/">;
@@ -1110,7 +1110,7 @@ declare module "nextjs-routes" {
   import type {
     GetServerSidePropsContext as NextGetServerSidePropsContext,
     GetServerSidePropsResult as NextGetServerSidePropsResult
-  } from "nextjs";
+  } from "next";
 
   export type Route =
     never;
@@ -1288,7 +1288,7 @@ declare module "nextjs-routes" {
   import type {
     GetServerSidePropsContext as NextGetServerSidePropsContext,
     GetServerSidePropsResult as NextGetServerSidePropsResult
-  } from "nextjs";
+  } from "next";
 
   export type Route =
     | DynamicRoute<"src/pages/[foo]/bar", { "foo": string }>;
@@ -1466,7 +1466,7 @@ declare module "nextjs-routes" {
   import type {
     GetServerSidePropsContext as NextGetServerSidePropsContext,
     GetServerSidePropsResult as NextGetServerSidePropsResult
-  } from "nextjs";
+  } from "next";
 
   export type Route =
     | StaticRoute<"/404">

--- a/src/core.ts
+++ b/src/core.ts
@@ -96,7 +96,7 @@ declare module "nextjs-routes" {
   import type {
     GetServerSidePropsContext as NextGetServerSidePropsContext,
     GetServerSidePropsResult as NextGetServerSidePropsResult
-  } from "nextjs";
+  } from "next";
 
   export type Route =
     ${


### PR DESCRIPTION
[ BEFORE ]
```ts
import type {
    GetServerSidePropsContext as NextGetServerSidePropsContext,
    GetServerSidePropsResult as NextGetServerSidePropsResult
} from "nextjs";
```

[ AFTER ] 
```ts
import type {
    GetServerSidePropsContext as NextGetServerSidePropsContext,
    GetServerSidePropsResult as NextGetServerSidePropsResult
} from "next";
```

For the "BEFORE" type, it has any type, so no child type such as previewData was inferred from the "NextGetServerSidePropsContext["previewData"] type.