### PR TITLE
Update filter method get more strict type

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { writeNextJSRoutes } from "./core.js";
-import { getAppDirectory, getPagesDirectory } from "./utils.js";
+import { getAppDirectory, getPagesDirectory, isNotUndefined } from "./utils.js";
 
 const logger: Pick<Console, "error" | "info"> = {
   error: (str: string) => console.error("[nextjs-routes] " + str),
@@ -12,7 +12,7 @@ function cli(): void {
   const dirs = [
     getPagesDirectory(process.cwd()),
     getAppDirectory(process.cwd()),
-  ].filter((x): x is string => x != undefined);
+  ].filter(isNotUndefined);
   if (dirs.length === 0) {
     logger.error(`Could not find a Next.js pages directory. Expected to find either 'pages' (1), 'src/pages' (2), or 'app' (3) in your project root.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ function cli(): void {
   const dirs = [
     getPagesDirectory(process.cwd()),
     getAppDirectory(process.cwd()),
-  ].filter((x) => x != undefined);
+  ].filter((x): x is string => x != undefined);
   if (dirs.length === 0) {
     logger.error(`Could not find a Next.js pages directory. Expected to find either 'pages' (1), 'src/pages' (2), or 'app' (3) in your project root.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ import { watch } from "chokidar";
 import type { NextConfig } from "next";
 import type { Configuration, WebpackPluginInstance } from "webpack";
 import { NextJSRoutesOptions, logger, writeNextJSRoutes } from "./core.js";
-import { getAppDirectory, getPagesDirectory } from "./utils.js";
+import { getAppDirectory, getPagesDirectory, isNotUndefined } from "./utils.js";
 
 type WebpackConfigContext = Parameters<NonNullable<NextConfig["webpack"]>>[1];
 
@@ -45,7 +45,7 @@ class NextJSRoutesPlugin implements WebpackPluginInstance {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const cwd = this.options?.cwd ?? process.cwd();
     const watchDirs = [getPagesDirectory(cwd), getAppDirectory(cwd)].filter(
-      (x): x is string => x !== undefined
+      isNotUndefined
     );
 
     if (watchDirs.length <= 0) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,3 +35,7 @@ export function findFiles(entry: string): string[] {
     return filepath;
   });
 }
+
+export function isNotUndefined<T>(value: T | undefined): value is T {
+  return value !== undefined;
+}


### PR DESCRIPTION
```ts
  const dirs = [
    getPagesDirectory(process.cwd()),
    getAppDirectory(process.cwd()),
  ].filter((x) => x != undefined);
```

In this case, "type" is specified as "(string | undefined)[]" even though the dirs variable cannot be an array with undefined. I supplemented this point.