### PR TITLE
Update lint and webpack disable

### DIFF
--- a/e2e/.eslintrc.json
+++ b/e2e/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires, no-undef
 const { join } = require("path");
 
 /**
@@ -8,6 +9,7 @@ const common = {
   mode: "production",
   output: {
     filename: "[name].cjs",
+    // eslint-disable-next-line no-undef
     path: join(__dirname, "dist"),
     libraryTarget: "commonjs2",
   },
@@ -37,6 +39,7 @@ const common = {
   },
 };
 
+// eslint-disable-next-line no-undef
 module.exports = [
   {
     ...common,


### PR DESCRIPTION
1. If you do `pnpm build` in the "e2e" folder path, the following warning will occur because "nextjs" will automatically run lint. I supplemented this part.

![image](https://user-images.githubusercontent.com/55759551/232652064-6f81274c-ba17-4049-8059-1088a8373091.png)

2. You are aware of the warnings given by "eslint" and you think the grammar is written as intended. If so, removing these warnings through "eslint-disable-next-line" will help you determine the actual error in the future. I supplemented this part.

![image](https://user-images.githubusercontent.com/55759551/232652135-96b7e058-a822-4604-bf4d-d61701838acb.png)

Please advise if there are any exceptions.