### PR TITLE
🔧 CLI: specify path to nextjs application (CI / Monorepo)

### DIFF
--- a/packages/nextjs-routes/src/cli.ts
+++ b/packages/nextjs-routes/src/cli.ts
@@ -8,13 +8,13 @@ const logger: Pick<Console, "error" | "info"> = {
   info: (str: string) => console.info("[nextjs-routes] " + str),
 };
 
-function cli(): void {
+function cli(dir = process.cwd()): void {
   const dirs = [
-    getPagesDirectory(process.cwd()),
-    getAppDirectory(process.cwd()),
+    getPagesDirectory(dir),
+    getAppDirectory(dir),
   ].filter(isNotUndefined);
   if (dirs.length === 0) {
-    logger.error(`Could not find a Next.js pages directory. Expected to find either 'pages' (1), 'src/pages' (2), or 'app' (3) in your project root.
+    logger.error(`Could not find a Next.js pages directory. Expected to find either 'pages' (1), 'src/pages' (2), or 'app' (3) in your project path ${dir}.
 
   1. https://nextjs.org/docs/basic-features/pages
   2. https://nextjs.org/docs/advanced-features/src-directory
@@ -22,9 +22,11 @@ function cli(): void {
   `);
     process.exit(1);
   } else {
-    writeNextJSRoutes({});
+    writeNextJSRoutes({
+      dir: dir,
+    });
     logger.info("Generated route types.");
   }
 }
 
-cli();
+cli(process.argv[2]);


### PR DESCRIPTION
In order to generate types for a specific project from root of a monorepo during CI, a subfolder should be specified.

E.g. `package.json`: 
```json
"codegen:routes:frontend": "nextjs-routes apps/frontend",
"codegen:routes:frontoffice": "nextjs-routes apps/frontoffice"
```

Arguments could be handled in a better way (`commander`, arguments validation, ...) but this currently works.