### PR TITLE
Address intercepting parallel routes

### DIFF
--- a/packages/nextjs-routes/src/core.ts
+++ b/packages/nextjs-routes/src/core.ts
@@ -394,39 +394,45 @@ export function getAppRoutes(files: string[], opts: Opts): string[] {
           .filter(
             (segment) => !(segment.startsWith("(") && segment.endsWith(")")),
           )
-          .reduce<string[] & {isParallel:boolean}>((acc, next) => {
-            let isParallel = !!acc.isParallel;
-            // ignore '@' prefixed segments as they are parallel routes
-            if (next.startsWith('@')) return Object.assign(acc, {isParallel: true});
+          .reduce<string[] & { isParallel: boolean }>(
+            (acc, next) => {
+              let isParallel = !!acc.isParallel;
+              // ignore '@' prefixed segments as they are parallel routes
+              if (next.startsWith("@"))
+                return Object.assign(acc, { isParallel: true });
 
-            // pass down normal routes
-            if (!isParallel) return Object.assign([...acc, next], {isParallel});
+              // pass down normal routes
+              if (!isParallel)
+                return Object.assign([...acc, next], { isParallel });
 
-            // a normal segment under a parallel route
-            if (!next.startsWith('(.')) return Object.assign([...acc, next], {isParallel})
+              // a normal segment under a parallel route
+              if (!next.startsWith("(."))
+                return Object.assign([...acc, next], { isParallel });
 
-            let temp = next;
+              let temp = next;
 
-            while (temp.startsWith('(.')){
-              if (temp.startsWith('(.)')) {
-                // all ok to remove  as refers to same segment level with the @ segment
-                temp = temp.slice(3)
+              while (temp.startsWith("(.")) {
+                if (temp.startsWith("(.)")) {
+                  // all ok to remove  as refers to same segment level with the @ segment
+                  temp = temp.slice(3);
+                }
+                if (temp.startsWith("(..)")) {
+                  // remove a segment as this goes up a level
+                  temp = temp.slice(4);
+                  acc.pop();
+                }
+                if (temp.startsWith("(...)")) {
+                  // this refers to base route
+                  // temp = temp.slice(5);
+                  return Object.assign([next], { isParallel });
+                }
+                if (!temp) return acc;
               }
-              if (temp.startsWith('(..)')){
-                // remove a segment as this goes up a level
-                temp = temp.slice(4);
-                acc.pop()
-              }
-              if (temp.startsWith('(...)')){
-                // this refers to base route
-                // temp = temp.slice(5);
-                return Object.assign( [next],{isParallel});
-              }
-              if (!temp) return acc;
-            }
 
-            return Object.assign( [...acc, temp],{isParallel});
-          }, Object.assign( [], {isParallel:false}))
+              return Object.assign([...acc, temp], { isParallel });
+            },
+            Object.assign([], { isParallel: false }),
+          )
           // remove page
           .filter((file) => !APP_DIRECTORY_ROUTABLE.includes(parse(file).name))
           .join("/"),

--- a/packages/nextjs-routes/src/core.ts
+++ b/packages/nextjs-routes/src/core.ts
@@ -394,6 +394,39 @@ export function getAppRoutes(files: string[], opts: Opts): string[] {
           .filter(
             (segment) => !(segment.startsWith("(") && segment.endsWith(")")),
           )
+          .reduce<string[] & {isParallel:boolean}>((acc, next) => {
+            let isParallel = !!acc.isParallel;
+            // ignore '@' prefixed segments as they are parallel routes
+            if (next.startsWith('@')) return Object.assign(acc, {isParallel: true});
+
+            // pass down normal routes
+            if (!isParallel) return Object.assign([...acc, next], {isParallel});
+
+            // a normal segment under a parallel route
+            if (!next.startsWith('(.')) return Object.assign([...acc, next], {isParallel})
+
+            let temp = next;
+
+            while (temp.startsWith('(.')){
+              if (temp.startsWith('(.)')) {
+                // all ok to remove  as refers to same segment level with the @ segment
+                temp = temp.slice(3)
+              }
+              if (temp.startsWith('(..)')){
+                // remove a segment as this goes up a level
+                temp = temp.slice(4);
+                acc.pop()
+              }
+              if (temp.startsWith('(...)')){
+                // this refers to base route
+                // temp = temp.slice(5);
+                return Object.assign( [next],{isParallel});
+              }
+              if (!temp) return acc;
+            }
+
+            return Object.assign( [...acc, temp],{isParallel});
+          }, Object.assign( [], {isParallel:false}))
           // remove page
           .filter((file) => !APP_DIRECTORY_ROUTABLE.includes(parse(file).name))
           .join("/"),
@@ -431,7 +464,7 @@ export function writeNextJSRoutes(options: NextJSRoutesOptions): void {
     ...defaultOptions,
     ...options,
   };
-  const files = [];
+  const files: string[] = [];
   const pagesDirectory = getPagesDirectory(opts.dir);
   if (pagesDirectory) {
     const routes = getPageRoutes(findFiles(pagesDirectory), {


### PR DESCRIPTION
this is an initial play to address #194 

### Parallel Support
it will filter out `@` prefixed segments

### Intercepting Support
will ignore out `(.)` prefixes  below at `@` prefixed segment

will pop segments when `(..)` prefix present below at `@` prefixed segment

will reset all segments to base when see a `(...)` prefix segment below at `@` prefixed segment